### PR TITLE
Fix for missing attribution and license.

### DIFF
--- a/msOffice/Excel/ActiveCell.ahk
+++ b/msOffice/Excel/ActiveCell.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/ActiveCell.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script demonstrates how to get a reference to the active cell in the active Excel application.
 
 xlApp := ComObjActive("Excel.Application")  ; Excel must be running.

--- a/msOffice/Excel/ActiveCell.ahk
+++ b/msOffice/Excel/ActiveCell.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/ActiveCell.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script demonstrates how to get a reference to the active cell in the active Excel application.
 

--- a/msOffice/Excel/ActiveCell_2.ahk
+++ b/msOffice/Excel/ActiveCell_2.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/ActiveCell_2.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script selects the cell to the right of the active cell. Excel must be running and not in Edit mode.
 

--- a/msOffice/Excel/ActiveCell_2.ahk
+++ b/msOffice/Excel/ActiveCell_2.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/ActiveCell_2.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script selects the cell to the right of the active cell. Excel must be running and not in Edit mode.
 
 xlApp := ComObjActive("Excel.Application")

--- a/msOffice/Excel/Active_row-Get_a_cell_in_a_specific_column.ahk
+++ b/msOffice/Excel/Active_row-Get_a_cell_in_a_specific_column.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Active_row-Get_a_cell_in_a_specific_column.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script will display the value of the cell in column 'D' of the active row.
 
 ; Excel hotkeys

--- a/msOffice/Excel/Active_row-Get_a_cell_in_a_specific_column.ahk
+++ b/msOffice/Excel/Active_row-Get_a_cell_in_a_specific_column.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Active_row-Get_a_cell_in_a_specific_column.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script will display the value of the cell in column 'D' of the active row.
 

--- a/msOffice/Excel/Borders_and_other_formatting.ahk
+++ b/msOffice/Excel/Borders_and_other_formatting.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Borders_and_other_formatting.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script copies example data from an object into a SafeArray. The SafeArray is then assigned to a Range in Excel.
 ; Some formatting is then added such as bold text, column widths and borders.

--- a/msOffice/Excel/Borders_and_other_formatting.ahk
+++ b/msOffice/Excel/Borders_and_other_formatting.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Borders_and_other_formatting.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script copies example data from an object into a SafeArray. The SafeArray is then assigned to a Range in Excel.
 ; Some formatting is then added such as bold text, column widths and borders.
 

--- a/msOffice/Excel/Cells.ahk
+++ b/msOffice/Excel/Cells.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Cells.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script demonstrates how to get a reference to a cell in the active Excel application.
 
 xlApp := ComObjActive("Excel.Application")  ; Excel must be running.

--- a/msOffice/Excel/Cells.ahk
+++ b/msOffice/Excel/Cells.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Cells.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script demonstrates how to get a reference to a cell in the active Excel application.
 

--- a/msOffice/Excel/Cells_in_a_column.ahk
+++ b/msOffice/Excel/Cells_in_a_column.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Cells_in_a_column.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script will look for the last non-blank cell in column A. Then it loops through each cell in column A starting at
 ; cell A1 all the way to the last non-blank cell.
 

--- a/msOffice/Excel/Cells_in_a_column.ahk
+++ b/msOffice/Excel/Cells_in_a_column.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Cells_in_a_column.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script will look for the last non-blank cell in column A. Then it loops through each cell in column A starting at
 ; cell A1 all the way to the last non-blank cell.

--- a/msOffice/Excel/Cells_in_a_column_2.ahk
+++ b/msOffice/Excel/Cells_in_a_column_2.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Cells_in_a_column_2.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script gets a range of cells in column A and B. (Like selecting cell A2 and then pressing Ctrl+Shift+Down and
 ; then Shift+Right.) Then each time the Ctrl+F12 hotkey is pressed it sends the next value.

--- a/msOffice/Excel/Cells_in_a_column_2.ahk
+++ b/msOffice/Excel/Cells_in_a_column_2.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Cells_in_a_column_2.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script gets a range of cells in column A and B. (Like selecting cell A2 and then pressing Ctrl+Shift+Down and
 ; then Shift+Right.) Then each time the Ctrl+F12 hotkey is pressed it sends the next value.
 

--- a/msOffice/Excel/Copy_from_one_sheet_to_another.ahk
+++ b/msOffice/Excel/Copy_from_one_sheet_to_another.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Copy_from_one_sheet_to_another.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; Usage:
 ;   Win+7 hotkey  - Assigns the active cell to the same address on Sheet2.
 ;   Ctrl+7 hotkey - Assigns a range of cells from the active worksheet to Sheet2.

--- a/msOffice/Excel/Copy_from_one_sheet_to_another.ahk
+++ b/msOffice/Excel/Copy_from_one_sheet_to_another.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Copy_from_one_sheet_to_another.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; Usage:
 ;   Win+7 hotkey  - Assigns the active cell to the same address on Sheet2.

--- a/msOffice/Excel/Copy_from_one_workbook_to_another.ahk
+++ b/msOffice/Excel/Copy_from_one_workbook_to_another.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Copy_from_one_workbook_to_another.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; These are the two files that will be used.
 Book1Path := A_ScriptDir "\Workbook1.xlsx"
 Book2Path := A_ScriptDir "\Workbook2.xlsx"  ; This workbook receives data when the Ctrl+1 hotkey is pressed. 

--- a/msOffice/Excel/Copy_from_one_workbook_to_another.ahk
+++ b/msOffice/Excel/Copy_from_one_workbook_to_another.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Copy_from_one_workbook_to_another.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; These are the two files that will be used.
 Book1Path := A_ScriptDir "\Workbook1.xlsx"

--- a/msOffice/Excel/Copy_rows_to_new_workbooks.ahk
+++ b/msOffice/Excel/Copy_rows_to_new_workbooks.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Copy_rows_to_new_workbooks.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script copies rows from one workbook into new workbooks. This was originally made for an "Ask for Help" question
 ; posted at: https://autohotkey.com/boards/viewtopic.php?f=5&t=34083

--- a/msOffice/Excel/Copy_rows_to_new_workbooks.ahk
+++ b/msOffice/Excel/Copy_rows_to_new_workbooks.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Copy_rows_to_new_workbooks.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script copies rows from one workbook into new workbooks. This was originally made for an "Ask for Help" question
 ; posted at: https://autohotkey.com/boards/viewtopic.php?f=5&t=34083
 ; To run this script you will need to set up an example workbook. You can look at the link above for details, but

--- a/msOffice/Excel/Excel_Get.ahk
+++ b/msOffice/Excel/Excel_Get.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Excel_Get.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; Excel_Get by jethrow (modified)
 ; Forum:    https://autohotkey.com/boards/viewtopic.php?f=6&t=31840
 ; Github:   https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Excel_Get.ahk

--- a/msOffice/Excel/Excel_Get.ahk
+++ b/msOffice/Excel/Excel_Get.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Excel_Get.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; Excel_Get by jethrow (modified)
 ; Forum:    https://autohotkey.com/boards/viewtopic.php?f=6&t=31840

--- a/msOffice/Excel/Find.ahk
+++ b/msOffice/Excel/Find.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Find.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script will find all values in a range.
 ; The script looks in a workbook for the text "abc123".
 ; The range searched is the used range on sheet 1, columns A-Z.

--- a/msOffice/Excel/Find.ahk
+++ b/msOffice/Excel/Find.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Find.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script will find all values in a range.
 ; The script looks in a workbook for the text "abc123".

--- a/msOffice/Excel/Find_2.ahk
+++ b/msOffice/Excel/Find_2.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Find_2.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script is a demonstration of the .Find method. It gets the value of the cell to the right of the active cell.
 ; Then it will find that value in the range "B:B" on Sheet2.
 

--- a/msOffice/Excel/Find_2.ahk
+++ b/msOffice/Excel/Find_2.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Find_2.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script is a demonstration of the .Find method. It gets the value of the cell to the right of the active cell.
 ; Then it will find that value in the range "B:B" on Sheet2.

--- a/msOffice/Excel/Find_3.ahk
+++ b/msOffice/Excel/Find_3.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Find_3.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; Usage:
 ;   Copy text to the clipboard.

--- a/msOffice/Excel/Find_3.ahk
+++ b/msOffice/Excel/Find_3.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Find_3.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; Usage:
 ;   Copy text to the clipboard.
 ;   Press F7 to search for the clipboard text in columns A and B.

--- a/msOffice/Excel/For-loop_worksheets_and_cells.ahk
+++ b/msOffice/Excel/For-loop_worksheets_and_cells.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/For-loop_worksheets_and_cells.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script opens a workbook and then loops through each sheet. Within each sheet, it finds the last non-blank cell in
 ; column A. It then loops through each cell in the Range from A1 to the last cell.

--- a/msOffice/Excel/For-loop_worksheets_and_cells.ahk
+++ b/msOffice/Excel/For-loop_worksheets_and_cells.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/For-loop_worksheets_and_cells.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script opens a workbook and then loops through each sheet. Within each sheet, it finds the last non-blank cell in
 ; column A. It then loops through each cell in the Range from A1 to the last cell.
 

--- a/msOffice/Excel/For-loop_worksheets_rows_and_cells.ahk
+++ b/msOffice/Excel/For-loop_worksheets_rows_and_cells.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/For-loop_worksheets_rows_and_cells.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script opens a workbook and then loops through each sheet. Within each sheet, it finds the last non-blank cell in
 ; column A. It then loops through each row in the Range from A1 to the last row. Within each row, it loops through each
 ; cell in the row starting at column A and going until the last non-blank cell in the row.

--- a/msOffice/Excel/For-loop_worksheets_rows_and_cells.ahk
+++ b/msOffice/Excel/For-loop_worksheets_rows_and_cells.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/For-loop_worksheets_rows_and_cells.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script opens a workbook and then loops through each sheet. Within each sheet, it finds the last non-blank cell in
 ; column A. It then loops through each row in the Range from A1 to the last row. Within each row, it loops through each

--- a/msOffice/Excel/Get sheet names and cells matching a color.ahk
+++ b/msOffice/Excel/Get sheet names and cells matching a color.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Get%20sheet%20names%20and%20cells%20matching%20a%20color.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script does the following:
 ;   - Open the test workbook (located in the same directory as this script -

--- a/msOffice/Excel/Get sheet names and cells matching a color.ahk
+++ b/msOffice/Excel/Get sheet names and cells matching a color.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Get%20sheet%20names%20and%20cells%20matching%20a%20color.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script does the following:
 ;   - Open the test workbook (located in the same directory as this script -
 ;     "..\Get sheet names and cells matching a color DATA.xlsx")

--- a/msOffice/Excel/GetActiveWorkbook.ahk
+++ b/msOffice/Excel/GetActiveWorkbook.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/GetActiveWorkbook.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script demonstrates getting a reference to the active workbook if more than one Excel Application is open. 
 ; The GetActiveObjects function is required. (Paste it into this script or #Include it.)
 ; GetActiveObjects - http://ahkscript.org/boards/viewtopic.php?f=6&t=6494

--- a/msOffice/Excel/GetActiveWorkbook.ahk
+++ b/msOffice/Excel/GetActiveWorkbook.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/GetActiveWorkbook.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script demonstrates getting a reference to the active workbook if more than one Excel Application is open. 
 ; The GetActiveObjects function is required. (Paste it into this script or #Include it.)

--- a/msOffice/Excel/IsInEditMode.ahk
+++ b/msOffice/Excel/IsInEditMode.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/IsInEditMode.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script tests if Excel is in edit mode. Many actions are forbidden while Excel is in edit-mode. They will generate
 ; warning messages instead of performing the requested action.

--- a/msOffice/Excel/IsInEditMode.ahk
+++ b/msOffice/Excel/IsInEditMode.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/IsInEditMode.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script tests if Excel is in edit mode. Many actions are forbidden while Excel is in edit-mode. They will generate
 ; warning messages instead of performing the requested action.
 

--- a/msOffice/Excel/Open_or_add_a_workbook.ahk
+++ b/msOffice/Excel/Open_or_add_a_workbook.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Open_or_add_a_workbook.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; Usage:
 ; F11 hotkey        - Open a workbook in the active instance of Excel.
 ; F12 hotkey        - Open a workbook in a new instance of Excel.

--- a/msOffice/Excel/Open_or_add_a_workbook.ahk
+++ b/msOffice/Excel/Open_or_add_a_workbook.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Open_or_add_a_workbook.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; Usage:
 ; F11 hotkey        - Open a workbook in the active instance of Excel.

--- a/msOffice/Excel/PageSetup.ahk
+++ b/msOffice/Excel/PageSetup.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/PageSetup.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script adds some example data to Excel and then sets some PageSetup properties.
 
 ; Constants

--- a/msOffice/Excel/PageSetup.ahk
+++ b/msOffice/Excel/PageSetup.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/PageSetup.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script adds some example data to Excel and then sets some PageSetup properties.
 

--- a/msOffice/Excel/Range (Loop).ahk
+++ b/msOffice/Excel/Range (Loop).ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Range%20(Loop).ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script gets/saves a reference to a Range object ('MyRange'). Then it loops through each item in the Range. Each
 ; item in the range is a Cell. Each cell is actually a Range object. ie: A range can contain several cells, or only one.
 

--- a/msOffice/Excel/Range (Loop).ahk
+++ b/msOffice/Excel/Range (Loop).ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Range%20(Loop).ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script gets/saves a reference to a Range object ('MyRange'). Then it loops through each item in the Range. Each
 ; item in the range is a Cell. Each cell is actually a Range object. ie: A range can contain several cells, or only one.

--- a/msOffice/Excel/Range.ahk
+++ b/msOffice/Excel/Range.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Range.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script demonstrates several ways to specify a Range. After each example, this script selects the Range and
 ; displays a MsgBox. 

--- a/msOffice/Excel/Range.ahk
+++ b/msOffice/Excel/Range.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Range.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script demonstrates several ways to specify a Range. After each example, this script selects the Range and
 ; displays a MsgBox. 
 

--- a/msOffice/Excel/SafeArray-Split_a_string_into_cells.ahk
+++ b/msOffice/Excel/SafeArray-Split_a_string_into_cells.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/SafeArray-Split_a_string_into_cells.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script creates a SafeArray from the example string. Linefeeds ("`n") are used to split the string into rows, and
 ; commas (",") are used to split each row into cells. The safearray is then put into a new Excel workbook starting at
 ; cell C2.

--- a/msOffice/Excel/SafeArray-Split_a_string_into_cells.ahk
+++ b/msOffice/Excel/SafeArray-Split_a_string_into_cells.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/SafeArray-Split_a_string_into_cells.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script creates a SafeArray from the example string. Linefeeds ("`n") are used to split the string into rows, and
 ; commas (",") are used to split each row into cells. The safearray is then put into a new Excel workbook starting at

--- a/msOffice/Excel/Save sheets as new workbooks.ahk
+++ b/msOffice/Excel/Save sheets as new workbooks.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Save%20sheets%20as%20new%20workbooks.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script prompts the user to select a workbook file. Then each sheet in the selected workbook is copied into a
 ; new workbook. Each new workbook is then saved to the same dir as the original file.
 

--- a/msOffice/Excel/Save sheets as new workbooks.ahk
+++ b/msOffice/Excel/Save sheets as new workbooks.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Save%20sheets%20as%20new%20workbooks.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script prompts the user to select a workbook file. Then each sheet in the selected workbook is copied into a
 ; new workbook. Each new workbook is then saved to the same dir as the original file.

--- a/msOffice/Excel/Worksheets-Activate_next_or_previous.ahk
+++ b/msOffice/Excel/Worksheets-Activate_next_or_previous.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Worksheets-Activate_next_or_previous.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; F8 hotkey to activate the next sheet.
 F8::

--- a/msOffice/Excel/Worksheets-Activate_next_or_previous.ahk
+++ b/msOffice/Excel/Worksheets-Activate_next_or_previous.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Excel/Worksheets-Activate_next_or_previous.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; F8 hotkey to activate the next sheet.
 F8::
     ; Get a reference to the active workbook. One (and only one) instance of Excel must be running.

--- a/msOffice/Office_2010_Constants_(class).ahk
+++ b/msOffice/Office_2010_Constants_(class).ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Office_2010_Constants_(class).ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; Made with OfficeInfo - https://autohotkey.com/boards/viewtopic.php?f=6&p=113884
 class OfficeConstants

--- a/msOffice/Office_2010_Constants_(class).ahk
+++ b/msOffice/Office_2010_Constants_(class).ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Office_2010_Constants_(class).ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; Made with OfficeInfo - https://autohotkey.com/boards/viewtopic.php?f=6&p=113884
 class OfficeConstants
 {

--- a/msOffice/Office_2010_Constants_(global).ahk
+++ b/msOffice/Office_2010_Constants_(global).ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Office_2010_Constants_(global).ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; Made with OfficeInfo - https://autohotkey.com/boards/viewtopic.php?f=6&p=113884
 _xlDialogChartSourceData:=541

--- a/msOffice/Office_2010_Constants_(global).ahk
+++ b/msOffice/Office_2010_Constants_(global).ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Office_2010_Constants_(global).ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; Made with OfficeInfo - https://autohotkey.com/boards/viewtopic.php?f=6&p=113884
 _xlDialogChartSourceData:=541
 _xlDialogPhonetic:=538

--- a/msOffice/Office_2010_Constants_(super_global).ahk
+++ b/msOffice/Office_2010_Constants_(super_global).ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Office_2010_Constants_(super_global).ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; Made with OfficeInfo - https://autohotkey.com/boards/viewtopic.php?f=6&p=113884
 global _xlDialogChartSourceData:=541

--- a/msOffice/Office_2010_Constants_(super_global).ahk
+++ b/msOffice/Office_2010_Constants_(super_global).ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Office_2010_Constants_(super_global).ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; Made with OfficeInfo - https://autohotkey.com/boards/viewtopic.php?f=6&p=113884
 global _xlDialogChartSourceData:=541
 global _xlDialogPhonetic:=538

--- a/msOffice/Outlook/COMAddIns.ahk
+++ b/msOffice/Outlook/COMAddIns.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/COMAddIns.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; **Probably needs to be run as admin**
 ; This script displays the Outlook addins. The user can choose to enable or disable the addins.

--- a/msOffice/Outlook/COMAddIns.ahk
+++ b/msOffice/Outlook/COMAddIns.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/COMAddIns.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; **Probably needs to be run as admin**
 ; This script displays the Outlook addins. The user can choose to enable or disable the addins.
 

--- a/msOffice/Outlook/CalendarViewMode.ahk
+++ b/msOffice/Outlook/CalendarViewMode.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/CalendarViewMode.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script activates the calendar and changes the view to the month calendar.
 

--- a/msOffice/Outlook/CalendarViewMode.ahk
+++ b/msOffice/Outlook/CalendarViewMode.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/CalendarViewMode.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script activates the calendar and changes the view to the month calendar.
 
 ; Constants

--- a/msOffice/Outlook/Events.ahk
+++ b/msOffice/Outlook/Events.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/Events.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script demonstrates handling events of the Outlook Application object. Other types of objects will have different
 ; events.
 

--- a/msOffice/Outlook/Events.ahk
+++ b/msOffice/Outlook/Events.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/Events.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script demonstrates handling events of the Outlook Application object. Other types of objects will have different
 ; events.

--- a/msOffice/Outlook/HTMLBody.ahk
+++ b/msOffice/Outlook/HTMLBody.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/HTMLBody.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script creates an email, adds "test.png" as an attachment, then includes the image in the body of the email.
 
 Image := A_ScriptDir "\test.png"  ; The path of the image to include.

--- a/msOffice/Outlook/HTMLBody.ahk
+++ b/msOffice/Outlook/HTMLBody.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/HTMLBody.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script creates an email, adds "test.png" as an attachment, then includes the image in the body of the email.
 

--- a/msOffice/Outlook/Hyperlink.ahk
+++ b/msOffice/Outlook/Hyperlink.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/Hyperlink.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script creates a new email and adds a hyperlink.
 
 ; Constants

--- a/msOffice/Outlook/Hyperlink.ahk
+++ b/msOffice/Outlook/Hyperlink.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/Hyperlink.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script creates a new email and adds a hyperlink.
 

--- a/msOffice/Outlook/Restrict.ahk
+++ b/msOffice/Outlook/Restrict.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/Restrict.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script loops through all undread messages in the inbox and asks the user if they want to reply.
 
 ; Constants

--- a/msOffice/Outlook/Restrict.ahk
+++ b/msOffice/Outlook/Restrict.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/Restrict.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script loops through all undread messages in the inbox and asks the user if they want to reply.
 

--- a/msOffice/Outlook/SaveAs.ahk
+++ b/msOffice/Outlook/SaveAs.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/SaveAs.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script saves the active mail item to a specific folder.
 ; The two hotkeys are the same except they use different folders.

--- a/msOffice/Outlook/SaveAs.ahk
+++ b/msOffice/Outlook/SaveAs.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/SaveAs.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script saves the active mail item to a specific folder.
 ; The two hotkeys are the same except they use different folders.
 

--- a/msOffice/Outlook/Sent.ahk
+++ b/msOffice/Outlook/Sent.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/Sent.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script determines if an email is displayed in "Read" or "Edit" mode. That is to say, if a new email is being
 ; composed then the user can edit the text within the Inspector window. By contrast, if the user has sent the email or
 ; if the user is the recipient of the email, then the text within the Inspector window is read-only.

--- a/msOffice/Outlook/Sent.ahk
+++ b/msOffice/Outlook/Sent.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/Sent.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script determines if an email is displayed in "Read" or "Edit" mode. That is to say, if a new email is being
 ; composed then the user can edit the text within the Inspector window. By contrast, if the user has sent the email or

--- a/msOffice/Outlook/SmtpAddress.ahk
+++ b/msOffice/Outlook/SmtpAddress.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/SmtpAddress.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script resolves an exchange user's display name to a SMTP address.
 ; An email is open in an Inspector window for this example.

--- a/msOffice/Outlook/SmtpAddress.ahk
+++ b/msOffice/Outlook/SmtpAddress.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/SmtpAddress.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script resolves an exchange user's display name to a SMTP address.
 ; An email is open in an Inspector window for this example.
 

--- a/msOffice/Outlook/Sort items.ahk
+++ b/msOffice/Outlook/Sort items.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/Sort%20items.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This example displays and selects each item in the Inbox in a sorted order.
 
 ; Constants

--- a/msOffice/Outlook/Sort items.ahk
+++ b/msOffice/Outlook/Sort items.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/Sort%20items.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This example displays and selects each item in the Inbox in a sorted order.
 

--- a/msOffice/Outlook/Subject.ahk
+++ b/msOffice/Outlook/Subject.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/Subject.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; Get the subject of the active item in Outlook. Works in both the main window and if the email is open in its own window.
 olApp := ComObjActive("Outlook.Application")  ; Outlook must be running.

--- a/msOffice/Outlook/Subject.ahk
+++ b/msOffice/Outlook/Subject.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Outlook/Subject.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; Get the subject of the active item in Outlook. Works in both the main window and if the email is open in its own window.
 olApp := ComObjActive("Outlook.Application")  ; Outlook must be running.
 MyWindow := olApp.ActiveWindow  ; Get the active window.

--- a/msOffice/PowerPoint/BulletFormat.ahk
+++ b/msOffice/PowerPoint/BulletFormat.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/PowerPoint/BulletFormat.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script will change bullets to a check marks in the selected row(s) of text.
 
 ; Usage:

--- a/msOffice/PowerPoint/BulletFormat.ahk
+++ b/msOffice/PowerPoint/BulletFormat.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/PowerPoint/BulletFormat.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script will change bullets to a check marks in the selected row(s) of text.
 

--- a/msOffice/PowerPoint/Find_and_replace_on_all_slides.ahk
+++ b/msOffice/PowerPoint/Find_and_replace_on_all_slides.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/PowerPoint/Find_and_replace_on_all_slides.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script replaces the text "abc" with "xyz" on every slide in the active presentation.
 
 ppApp := ComObjActive("Powerpoint.Application")

--- a/msOffice/PowerPoint/Find_and_replace_on_all_slides.ahk
+++ b/msOffice/PowerPoint/Find_and_replace_on_all_slides.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/PowerPoint/Find_and_replace_on_all_slides.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script replaces the text "abc" with "xyz" on every slide in the active presentation.
 

--- a/msOffice/PowerPoint/Set_line_spacing.ahk
+++ b/msOffice/PowerPoint/Set_line_spacing.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/PowerPoint/Set_line_spacing.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script changes the line spacing of selected text.
 

--- a/msOffice/PowerPoint/Set_line_spacing.ahk
+++ b/msOffice/PowerPoint/Set_line_spacing.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/PowerPoint/Set_line_spacing.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script changes the line spacing of selected text.
 
 #IfWinActive ahk_class PPTFrameClass

--- a/msOffice/Word/Bookmarks.ahk
+++ b/msOffice/Word/Bookmarks.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Word/Bookmarks.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script creates a new word documennt from a template. Then it inserts text into two bookmarks.
 ; The template (Bookmarks.dotx) has two bookmarks named "MyBookmark1" and "MyBookmark2".
 

--- a/msOffice/Word/Bookmarks.ahk
+++ b/msOffice/Word/Bookmarks.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Word/Bookmarks.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script creates a new word documennt from a template. Then it inserts text into two bookmarks.
 ; The template (Bookmarks.dotx) has two bookmarks named "MyBookmark1" and "MyBookmark2".

--- a/msOffice/Word/CommandBars.ahk
+++ b/msOffice/Word/CommandBars.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Word/CommandBars.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script shows some actions using CommandBars and CommandBarControl objects. Use the F7 hotkey to display the
 ; available controls. Then use FindControl, as shown with the F9 and F10 hotkeys below, to execute a control action. The

--- a/msOffice/Word/CommandBars.ahk
+++ b/msOffice/Word/CommandBars.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Word/CommandBars.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script shows some actions using CommandBars and CommandBarControl objects. Use the F7 hotkey to display the
 ; available controls. Then use FindControl, as shown with the F9 and F10 hotkeys below, to execute a control action. The
 ; use of CommandBars in some Microsoft Office applications has been superseded by the ribbon, but CommandBars can be

--- a/msOffice/Word/Document_collect_clipboard_data.ahk
+++ b/msOffice/Word/Document_collect_clipboard_data.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Word/Document_collect_clipboard_data.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script creates a new document to hold stuff from the clipboard.
 

--- a/msOffice/Word/Document_collect_clipboard_data.ahk
+++ b/msOffice/Word/Document_collect_clipboard_data.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Word/Document_collect_clipboard_data.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script creates a new document to hold stuff from the clipboard.
 
 ; Usage

--- a/msOffice/Word/Is_file_open.ahk
+++ b/msOffice/Word/Is_file_open.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Word/Is_file_open.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿FilePath := A_ScriptDir "\New Microsoft Word Document.docx"  ; Path to a Word document.
 if FileOpen(FilePath, "rw") ; FileOpen fails if the file is already open.
     FileStatus := "not open"

--- a/msOffice/Word/Is_file_open.ahk
+++ b/msOffice/Word/Is_file_open.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Word/Is_file_open.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿FilePath := A_ScriptDir "\New Microsoft Word Document.docx"  ; Path to a Word document.
 if FileOpen(FilePath, "rw") ; FileOpen fails if the file is already open.

--- a/msOffice/Word/Open_a_password_protected_document.ahk
+++ b/msOffice/Word/Open_a_password_protected_document.ahk
@@ -1,3 +1,7 @@
+; By kon
+; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Word/Open_a_password_protected_document.ahk
+; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+
 ﻿; This script opens a Word document and prompts the user for a password if it is password protected.
 
 ; Try to open the Word document using this password. If the document is password protected this password should fail and

--- a/msOffice/Word/Open_a_password_protected_document.ahk
+++ b/msOffice/Word/Open_a_password_protected_document.ahk
@@ -1,6 +1,6 @@
 ; By kon
 ; Taken from - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/Examples/Word/Open_a_password_protected_document.ahk
-; Liscence - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
+; License - https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE
 
 ﻿; This script opens a Word document and prompts the user for a password if it is password protected.
 


### PR DESCRIPTION
Fix for missing attribution and license.

This repository (AHK-libs-and-classes-collection) includes various files taken from https://github.com/ahkon/MS-Office-COM-Basics
No attribution was given to the original author. 
The [license](https://github.com/ahkon/MS-Office-COM-Basics/blob/master/LICENSE) was removed.
